### PR TITLE
fix:onStart事件未配置报错问题修复

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -96,9 +96,6 @@ class MapViewDirections extends Component {
 				language = 'en',
 				directionsServiceBaseUrl = 'https://mapapi.cloud.huawei.com/mapApi/v1/routeService/',
 			} = props; 
-			//https://mapapi.cloud.huawei.com/mapApi/v1/routeService/walking
-			//https://mapapi.cloud.huawei.com/mapApi/v1/routeService/bicycling
-			//https://mapapi.cloud.huawei.com/mapApi/v1/routeService/driving
 			if(mode=='TRANSIT'){
 				console.warn(`MapViewDirections Error: homary dones not support transit model`)
 				return;
@@ -118,7 +115,7 @@ class MapViewDirections extends Component {
 				origin,
 				destination,
 			} = routes;
-			onStart({
+			onStart && onStart({
 				origin,
 				destination,
 			});


### PR DESCRIPTION
# Summary

本次提交是为了修复MapViewDirections未配置onStart事件报错，close #11。
此次修改添加了onStart方法是否存在的判断：在调用onStart事件方法的时候，判断onStart是否存在，如果存在才会调用onStart方法，此次修改不会影响原先功能。

## Test Plant

![7312](https://github.com/user-attachments/assets/5a837eb1-7ba6-455b-98c9-3edef8008b80)

## Checklist
<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [X] 更新了 JS/TS 代码

