### PR TITLE
fix:修改鸿蒙请求地图api函数方法名

### DIFF
--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -97,7 +97,7 @@ class MapViewDirections extends Component {
 				directionsServiceBaseUrl = 'https://mapapi.cloud.huawei.com/mapApi/v1/routeService/',
 			} = props; 
 			if(mode=='TRANSIT'){
-				console.warn(`MapViewDirections Error: homary dones not support transit model`)
+				console.warn(`MapViewDirections Error: peta lMap dones not support transit model`)
 				return;
 			}
 			if (!apikey) {

--- a/src/MapViewDirections.js
+++ b/src/MapViewDirections.js
@@ -35,7 +35,7 @@ class MapViewDirections extends Component {
 
 	renderRouteBySystem = ()=> {
 		if(Platform.OS == 'harmony'){
-			this.homaryFetchAndRenderRoute(this.props)
+			this.petalMapFetchAndRenderRoute(this.props)
 		}else{
 			this.fetchAndRenderRoute(this.props)
 		}
@@ -83,7 +83,7 @@ class MapViewDirections extends Component {
 		return points;
 	}
 
-	homaryFetchAndRenderRoute = (props) => {
+	petalMapFetchAndRenderRoute = (props) => {
 		{
 			let {
 				origin: initialOrigin,
@@ -119,7 +119,7 @@ class MapViewDirections extends Component {
 				origin,
 				destination,
 			});
-			this.homaryFetchRoute(directionsServiceBaseUrl, origin, destination, apikey, mode, language)
+			this.petalMapFetchRoute(directionsServiceBaseUrl, origin, destination, apikey, mode, language)
 				.then(results => {
 					this.setState({
 						coordinates: results.coordinates,
@@ -140,7 +140,7 @@ class MapViewDirections extends Component {
 	
 	}
 
-	homaryFetchRoute(directionsServiceBaseUrl, origin, destination, apikey, mode, language) {
+	petalMapFetchRoute(directionsServiceBaseUrl, origin, destination, apikey, mode, language) {
 		const typeMap = {
 			DRIVING: 'driving',
 			BICYCLING: 'bicycling',


### PR DESCRIPTION
# Summary

本次提交是为了修改鸿蒙请求地图api函数名称，使之更容易理解，close #21。
此次修改不会影响原先功能。

## Test Plant

![7312](https://github.com/user-attachments/assets/5a837eb1-7ba6-455b-98c9-3edef8008b80)

## Checklist
<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [X] 已经与 Android 或 iOS 平台做过效果/功能对比
- [X] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [X] 更新了 JS/TS 代码

